### PR TITLE
Strip newlines from config paths

### DIFF
--- a/topy/src/main.py
+++ b/topy/src/main.py
@@ -32,6 +32,7 @@ def from_files(paths):
         paths = paths.split('\t')
     items = []
     for path in paths:
+        path = path.rstrip()
         tlist = from_file(path)
         tlist.indent()
         # set file name as project title


### PR DESCRIPTION
Strip trailing whitespace/newlines from paths read from config file. I set my editors to strip trailing whitespace and append a newline on save, so the last path in my lists file was breaking.
