### PR TITLE
Add white space after last tag of project text

### DIFF
--- a/todoflow/todoitem.py
+++ b/todoflow/todoitem.py
@@ -80,6 +80,8 @@ class Todoitem(object):
 
     def tag(self, tag_to_use, param=None):
         self.text = tu.add_tag(self.text, tag_to_use, param)
+        if self.is_project:
+            self.text += " "
 
     def remove_tag(self, tag_to_remove):
         self.text = tu.remove_tag(self.text, tag_to_remove)


### PR DESCRIPTION
Fixes an issue where tags added to projects leave no space between the tag and the trailing ':'.
Causing the TaskPaper Mac App to not not recognise the tag.